### PR TITLE
Hierarchical vis support (metrics for every bucket/level)

### DIFF
--- a/public/decorators/agg_configs.js
+++ b/public/decorators/agg_configs.js
@@ -10,11 +10,14 @@ export function decorateVisAggConfigsProvider(Private) {
   function removeEmptyValues(obj) {
     return Object.keys(obj)
       .filter(k => obj[k] != null) // Filters out undefined and null objects
-      .reduce((newObj, k) =>
-        typeof obj[k] === 'object' ?
-          { ...newObj, [k]: removeEmptyValues(obj[k]) } : // Recursive call
-          { ...newObj, [k]: obj[k] },
-        {});
+      .reduce((newObj, k) => {
+        // Recursive call for arrays
+        if (Array.isArray(obj[k])) return { ...newObj, [k]: obj[k].map(removeEmptyValues) };
+        // Recursive call for objects
+        return typeof obj[k] === 'object' ?
+          { ...newObj, [k]: removeEmptyValues(obj[k]) } :
+          { ...newObj, [k]: obj[k] };
+      }, {});
   }
 
   const toDslFn = AggConfigs.prototype.toDsl;

--- a/public/decorators/agg_configs.js
+++ b/public/decorators/agg_configs.js
@@ -1,0 +1,28 @@
+import * as prov from 'ui/vis/agg_configs';
+
+export function decorateVisAggConfigsProvider(Private) {
+  const AggConfigs = prov.AggConfigs || Private(prov.VisAggConfigsProvider);
+
+  /**
+   * Recursively removes undefined values from object.
+   * @param {*} obj
+   */
+  function removeEmptyValues(obj) {
+    return Object.keys(obj)
+      .filter(k => obj[k] != null) // Filters out undefined and null objects
+      .reduce((newObj, k) =>
+        typeof obj[k] === 'object' ?
+          { ...newObj, [k]: removeEmptyValues(obj[k]) } : // Recursive call
+          { ...newObj, [k]: obj[k] },
+        {});
+  }
+
+  const toDslFn = AggConfigs.prototype.toDsl;
+  AggConfigs.prototype.toDsl = function () {
+    const isUsingFormula = !!this.vis.aggs.byTypeName.datasweet_formula;
+    const dsl = toDslFn.apply(this, arguments);
+    // Removes empty `datasweet_formula` aggs from dsl query if needed.
+    //  This happens when `vis.isHierarchical()` returns true
+    return isUsingFormula && this.vis.isHierarchical() ? removeEmptyValues(dsl) : dsl;
+  };
+};

--- a/public/decorators/lib/apply_column_groups.js
+++ b/public/decorators/lib/apply_column_groups.js
@@ -1,0 +1,17 @@
+/**
+ * Organizes columns in column groups.
+ * This is used when `vis.isHierarchical()` returns true,
+ *  usually when calculating metrics for every bucket/level.
+ * @param {*} columns
+ * @param {*} vis
+ */
+export function applyColumnGroups(columns, vis) {
+  const isUsingFormula = !!vis.aggs.byTypeName.datasweet_formula;
+  if (!isUsingFormula || isUsingFormula && !vis.isHierarchical()) return;
+  let columnGroup = 0;
+  columns = columns.map(c => {
+    if (c.aggConfig.type.type === 'buckets') columnGroup++;
+    c.columnGroup = columnGroup;
+    return c;
+  });
+}

--- a/public/decorators/lib/apply_formula.js
+++ b/public/decorators/lib/apply_formula.js
@@ -6,6 +6,7 @@ export function AggResponseFormulaProvider(Private)  {
   const FormulaParser = Private(FormulaParserProvider);
   const parser = new FormulaParser(true);
   const varPrefix = 'agg';
+  const prefixRegExpr = new RegExp(varPrefix, 'g');
 
   function hasFormulas(cols) {
     return find(cols, 'aggConfig.type.name', aggTypeFormulaId) !== undefined;
@@ -20,11 +21,15 @@ export function AggResponseFormulaProvider(Private)  {
 
     each(cols, (c, i)=> {
       const colIndex = i;
-      const key = varPrefix + c.aggConfig.id.replace('.', '_');
+      const columnGroupPrefix = c.columnGroup != null ? `colGroup${c.columnGroup}_` : '';
+      const key = columnGroupPrefix + varPrefix + c.aggConfig.id.replace('.', '_');
 
       // formula ?
       if (c.aggConfig.type.name === aggTypeFormulaId) {
-        const f = get(c.aggConfig.params, 'formula', '').trim();
+        const f = get(c.aggConfig.params, 'formula', '')
+          .trim()
+          // Adds columnGroup to prefix
+          .replace(prefixRegExpr, columnGroupPrefix + varPrefix);
         if (f.length > 0) {
           res.formulas.push({
             colIndex,

--- a/public/decorators/lib/apply_formula_total.js
+++ b/public/decorators/lib/apply_formula_total.js
@@ -6,6 +6,7 @@ export function TableTotalFormulaProvider(Private)  {
   const FormulaParser = Private(FormulaParserProvider);
   const parser = new FormulaParser(true);
   const varPrefix = 'agg';
+  const prefixRegExpr = new RegExp(varPrefix, 'g');
 
   function hasFormulas(cols) {
     return find(cols, 'aggConfig.type.name', aggTypeFormulaId) !== undefined;
@@ -15,11 +16,15 @@ export function TableTotalFormulaProvider(Private)  {
     const res = { series: {}, formulas:[] };
 
     each(cols, (c, colIndex)=> {
-      const key = varPrefix + c.aggConfig.id.replace('.', '_');
+      const columnGroupPrefix = c.columnGroup != null ? `colGroup${c.columnGroup}_` : '';
+      const key = columnGroupPrefix + varPrefix + c.aggConfig.id.replace('.', '_');
 
       // formula ?
       if (c.aggConfig.type.name === aggTypeFormulaId) {
-        const f = get(c.aggConfig.params, 'formula', '').trim();
+        const f = get(c.aggConfig.params, 'formula', '')
+          .trim()
+          // Adds columnGroup to prefix
+          .replace(prefixRegExpr, columnGroupPrefix + varPrefix);
         if (f.length > 0) {
           res.formulas.push({
             colIndex,

--- a/public/decorators/response_writer.js
+++ b/public/decorators/response_writer.js
@@ -2,6 +2,7 @@ import * as prov from 'ui/agg_response/tabify/_response_writer';
 import { AggResponseHiddenColumnsProvider } from './lib/apply_hidden';
 import { AggResponseFormulaProvider } from './lib/apply_formula';
 import { TableTotalFormulaProvider } from './lib/apply_formula_total';
+import { applyColumnGroups } from './lib/apply_column_groups';
 
 export function decorateTabbedAggResponseWriterProvider(Private) {  
   const TabbedAggResponseWriter = prov.TabbedAggResponseWriter || Private(prov.TabbedAggResponseWriterProvider);
@@ -12,6 +13,7 @@ export function decorateTabbedAggResponseWriterProvider(Private) {
   const responseFn = TabbedAggResponseWriter.prototype.response;
   TabbedAggResponseWriter.prototype.response = function () {
     const resp = responseFn.apply(this, arguments);
+    applyColumnGroups(this.columns, this.vis);
     applyFormulas(this.columns, resp);
     applyFormulaTotal(this.columns, resp);
     applyHiddenCols(this.columns, resp);

--- a/public/formula_hack.js
+++ b/public/formula_hack.js
@@ -2,11 +2,12 @@ import { reduce } from 'lodash';
 import { uiModules } from  'ui/modules';
 import chrome from 'ui/chrome';
 import { decorateVisAggConfigProvider } from './decorators/agg_config';
+import { decorateVisAggConfigsProvider } from './decorators/agg_configs';
 import { decorateAggTypes } from './decorators/agg_types';
 import { decorateTabbedAggResponseWriterProvider } from './decorators/response_writer';
 import hiddenTpl from './decorators/agg_hidden.html';
 import titleTpl from './decorators/agg_title.html';
-import './decorators/agg_table'
+import './decorators/agg_table';
 
 
 const appId = chrome.getApp().id;
@@ -16,8 +17,9 @@ if (appId === 'kibana' || appId === 'dashboardViewer') {
 
   uiModules
   .get('datasweet/formula', ['kibana'])
-  .run((Private) => {    
+  .run((Private) => {
     decorateVisAggConfigProvider(Private);
+    decorateVisAggConfigsProvider(Private);
     decorateAggTypes(Private);
     decorateTabbedAggResponseWriterProvider(Private);
   });


### PR DESCRIPTION
Guys, another fix for `datasweet-formula` in Table visualization:

When creating a table split by some kind of bucket, adding a formula metric and selecting `Calculate metrics for every bucket/level` in options, Kibana shows this error:
![image](https://user-images.githubusercontent.com/16384428/44055435-c5033d28-9f1b-11e8-9770-26aaaafaf00d.png)

To fix this, I created a `AggConfigs.toDsl` decorator that removes `undefined`values from `dsl` object and also added a `columnGroup` config in the response. This is the final result:
![image](https://user-images.githubusercontent.com/16384428/44055763-c0a71d20-9f1c-11e8-8af9-0ff1f0e9d741.png)

The column group config is needed in order to calculate the formulas separately!

This fix was tested in `6.1.1` version only. If you have any suggestion or change requests, please let me know!